### PR TITLE
Added support for single-quoted strings and commenting

### DIFF
--- a/bbedit/groovy.plist
+++ b/bbedit/groovy.plist
@@ -1,121 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>BBEditDocumentType</key>
-    <string>CodelessLanguageModule</string>
-    <key>BBLMLanguageCode</key>
-    <string>GRVY</string>
-    <key>BBLMLanguageDisplayName</key>
-    <string>Groovy</string>
-    <key>BBLMSuffixMap</key>
-    <array>
-      <dict>
-        <key>BBLMLanguageSuffix</key>
-        <string>.groovy</string>
-      </dict>
-    </array>
-    <key>BBLMColorsSyntax</key>
-    <true/>
-    <key>BBLMScansFunctions</key>
-    <true/>
-    <key>BBLMSupportsTextCompletion</key>
-    <true/>
-    <key>BBLMKeywordList</key>
-    <array>
-      <string>abstract</string>
-      <string>as</string>
-      <string>assert</string>
-      <string>boolean</string>
-      <string>break</string>
-      <string>byte</string>
-      <string>case</string>
-      <string>catch</string>
-      <string>char</string>
-      <string>class</string>
-      <string>const</string>
-      <string>continue</string>
-      <string>def</string>
-      <string>default</string>
-      <string>do</string>
-      <string>double</string>
-      <string>else</string>
-      <string>enum</string>
-      <string>extends</string>
-      <string>false</string>
-      <string>final</string>
-      <string>finally</string>
-      <string>float</string>
-      <string>for</string>
-      <string>goto</string>
-      <string>if</string>
-      <string>implements</string>
-      <string>import</string>
-      <string>in</string>
-      <string>instanceof</string>
-      <string>int</string>
-      <string>interface</string>
-      <string>long</string>
-      <string>native</string>
-      <string>new</string>
-      <string>null</string>
-      <string>package</string>
-      <string>private</string>
-      <string>protected</string>
-      <string>public</string>
-      <string>return</string>
-      <string>short</string>
-      <string>static</string>
-      <string>strictfp</string>
-      <string>super</string>
-      <string>switch</string>
-      <string>synchronized</string>
-      <string>this</string>
-      <string>threadsafe</string>
-      <string>throw</string>
-      <string>throws</string>
-      <string>transient</string>
-      <string>true</string>
-      <string>try</string>
-      <string>void</string>
-      <string>volatile</string>
-      <string>while</string>
-    </array>
-    <key>BBLMPredefinedNameList</key>
-    <array>
-      <string>GIVEN</string>
-      <string>WHEN</string>
-      <string>THEN</string>
-      <string>AND</string>
-    </array>
-    <key>Language Features</key>
-    <dict>
-      <key>Open Block Comments</key>
-      <string>/*</string>
-      <key>Close Block Comments</key>
-      <string>*/</string>
-      <key>Open Line Comments</key>
-      <string>//</string>
-      <key>Identifier and Keyword Character Class</key>
-      <string>a-zA-Z0-9_</string>
-      <key>Open Strings 1</key>
-      <string>"</string>
-      <key>Close Strings 1</key>
-      <string>"</string>
-      <key>Escape Char in Strings 1</key>
-      <string>\</string>
-      <key>End-of-line Ends Strings 1</key>
-      <true/>
-      <key>Prefix for Functions</key>
-      <string>def</string>
-      <key>Open Parameter Lists</key>
-      <string>(</string>
-      <key>Close Parameter Lists</key>
-      <string>)</string>
-      <key>Open Statement Blocks</key>
-      <string>{</string>
-      <key>Close Statement Blocks</key>
-      <string>}</string>            
-    </dict>
-  </dict>
+<dict>
+	<key>BBEditDocumentType</key>
+	<string>CodelessLanguageModule</string>
+	<key>BBLMLanguageCode</key>
+	<string>GRVY</string>
+	<key>BBLMLanguageDisplayName</key>
+	<string>Groovy</string>
+	<key>BBLMSuffixMap</key>
+	<array>
+		<dict>
+			<key>BBLMLanguageSuffix</key>
+			<string>.groovy</string>
+		</dict>
+	</array>
+	<key>BBLMColorsSyntax</key>
+	<true/>
+	<key>BBLMScansFunctions</key>
+	<true/>
+	<key>BBLMSupportsTextCompletion</key>
+	<true/>
+	<key>BBLMKeywordList</key>
+	<array>
+		<string>abstract</string>
+		<string>as</string>
+		<string>assert</string>
+		<string>boolean</string>
+		<string>break</string>
+		<string>byte</string>
+		<string>case</string>
+		<string>catch</string>
+		<string>char</string>
+		<string>class</string>
+		<string>const</string>
+		<string>continue</string>
+		<string>def</string>
+		<string>default</string>
+		<string>do</string>
+		<string>double</string>
+		<string>else</string>
+		<string>enum</string>
+		<string>extends</string>
+		<string>false</string>
+		<string>final</string>
+		<string>finally</string>
+		<string>float</string>
+		<string>for</string>
+		<string>goto</string>
+		<string>if</string>
+		<string>implements</string>
+		<string>import</string>
+		<string>in</string>
+		<string>instanceof</string>
+		<string>int</string>
+		<string>interface</string>
+		<string>long</string>
+		<string>native</string>
+		<string>new</string>
+		<string>null</string>
+		<string>package</string>
+		<string>private</string>
+		<string>protected</string>
+		<string>public</string>
+		<string>return</string>
+		<string>short</string>
+		<string>static</string>
+		<string>strictfp</string>
+		<string>super</string>
+		<string>switch</string>
+		<string>synchronized</string>
+		<string>this</string>
+		<string>threadsafe</string>
+		<string>throw</string>
+		<string>throws</string>
+		<string>transient</string>
+		<string>true</string>
+		<string>try</string>
+		<string>void</string>
+		<string>volatile</string>
+		<string>while</string>
+	</array>
+	<key>BBLMPredefinedNameList</key>
+	<array>
+		<string>GIVEN</string>
+		<string>WHEN</string>
+		<string>THEN</string>
+		<string>AND</string>
+	</array>
+	<key>Language Features</key>
+	<dict>
+		<key>Open Block Comments</key>
+		<string>/*</string>
+		<key>Close Block Comments</key>
+		<string>*/</string>
+		<key>Open Line Comments</key>
+		<string>//</string>
+		<key>Identifier and Keyword Character Class</key>
+		<string>a-zA-Z0-9_</string>
+		<key>Open Strings 1</key>
+		<string>&quot;</string>
+		<key>Open Strings 2</key>
+		<string>&apos;</string>
+		<key>Close Strings 1</key>
+		<string>&quot;</string>
+		<key>Close Strings 2</key>
+		<string>&apos;</string>
+		<key>Escape Char in Strings 1</key>
+		<string>\</string>
+		<key>End-of-line Ends Strings 1</key>
+		<true/>
+		<key>Prefix for Functions</key>
+		<string>def</string>
+		<key>Open Parameter Lists</key>
+		<string>(</string>
+		<key>Close Parameter Lists</key>
+		<string>)</string>
+		<key>Open Statement Blocks</key>
+		<string>{</string>
+		<key>Close Statement Blocks</key>
+		<string>}</string>
+	</dict>
+</dict>
 </plist>

--- a/bbedit/groovy.plist
+++ b/bbedit/groovy.plist
@@ -121,5 +121,7 @@
 		<key>Close Statement Blocks</key>
 		<string>}</string>
 	</dict>
+	<key>BBLMCommentLineDefault</key>
+	<string>//</string>
 </dict>
 </plist>


### PR DESCRIPTION
The keys needed for BBEdit to recognize single-quoted strings and for the comment/uncomment menu item to work were missing. I've added them.
