### PR TITLE
Added Jenkinsfile as a filename that should default to Groovy

### DIFF
--- a/bbedit/groovy.plist
+++ b/bbedit/groovy.plist
@@ -14,6 +14,10 @@
 			<key>BBLMLanguageSuffix</key>
 			<string>.groovy</string>
 		</dict>
+	</array>	
+	<key>BBLMFileNamesToMatch</key>
+	<array>
+		<string>Jenkinsfile</string>
 	</array>
 	<key>BBLMColorsSyntax</key>
 	<true/>


### PR DESCRIPTION
I added Jenkinsfile as a filename to the plist so that a Jenkinsfile is recognized as Groovy by default.